### PR TITLE
[NEW] ModuleADUC - Introduce Attribute Grid in Module ADUC

### DIFF
--- a/packages/OpenRSATGUI/ufrmmoduleaduc.lfm
+++ b/packages/OpenRSATGUI/ufrmmoduleaduc.lfm
@@ -585,78 +585,74 @@ object FrmModuleADUC: TFrmModuleADUC
         OnChange = CheckBox_IncludeSubContainerChange
       end
     end
-  end
-  object Panel5: TPanel
-    AnchorSideRight.Control = Owner
-    AnchorSideRight.Side = asrBottom
-    Left = 629
-    Height = 291
-    Top = 61
-    Width = 410
-    Align = alRight
-    BorderSpacing.Top = 33
-    BorderSpacing.Right = 4
-    BorderSpacing.Bottom = 4
-    BevelOuter = bvNone
-    ClientHeight = 291
-    ClientWidth = 410
-    TabOrder = 4
-    Visible = False
-    object GridAttributes: TTisGrid
+    object Panel5: TPanel
       AnchorSideRight.Side = asrBottom
-      Left = 0
-      Height = 287
-      Top = 0
+      Left = 215
+      Height = 316
+      Top = 33
       Width = 410
-      Align = alClient
-      BorderSpacing.Bottom = 4
-      Header.AutoSizeIndex = -1
-      Header.Columns = <      
-        item
-          Options = [coAllowClick, coDraggable, coEnabled, coParentBidiMode, coParentColor, coResizable, coShowDropMark, coVisible, coAllowFocus, coWrapCaption, coEditable]
-          Position = 0
-          Text = 'Attributes'
-          Width = 102
-          PropertyName = 'attributes'
-          ReadOnly = True
-        end      
-        item
-          Options = [coAllowClick, coDraggable, coEnabled, coParentBidiMode, coParentColor, coResizable, coShowDropMark, coVisible, coAllowFocus, coWrapCaption, coEditable]
-          Position = 1
-          Tag = 1
-          Text = 'Values'
-          Width = 282
-          PropertyName = 'values'
-          ReadOnly = True
-        end>
-      Header.DefaultHeight = 18
-      Header.Height = 28
-      Header.MainColumn = 1
-      Header.MaxHeight = 100
-      Header.MinHeight = 18
-      Header.Options = [hoColumnResize, hoDblClickResize, hoDrag, hoShowSortGlyphs, hoVisible, hoHeaderClickAutoSort]
-      Header.SortColumn = 0
-      Header.Style = hsFlatButtons
-      PopupMenu = PopupMenu1
-      TabOrder = 0
-      SelectedAndTotalLabel = Label1
-      TreeOptions.MiscOptions = [toFullRepaintOnResize, toGridExtensions, toInitOnSave, toReadOnly, toVariableNodeHeight, toFullRowDrag, toEditOnClick]
-      TreeOptions.SelectionOptions = [toDisableDrawSelection, toExtendedFocus, toMultiSelect, toRightClickSelect, toSimpleDrawSelection]
-      ZebraColor = 15593713
-      PopupMenuOptions = [pmoShowFind, pmoShowFindNext]
-      FilterOptions.CaseInsensitive = True
-      OnMouseDown = GridAttributesMouseDown
+      Align = alRight
+      BevelOuter = bvNone
+      ClientHeight = 316
+      ClientWidth = 410
+      TabOrder = 2
+      Visible = False
+      object GridAttributes: TTisGrid
+        AnchorSideRight.Side = asrBottom
+        Left = 0
+        Height = 312
+        Top = 0
+        Width = 410
+        Align = alClient
+        BorderSpacing.Bottom = 4
+        Header.AutoSizeIndex = -1
+        Header.Columns = <        
+          item
+            Options = [coAllowClick, coDraggable, coEnabled, coParentBidiMode, coParentColor, coResizable, coShowDropMark, coVisible, coAllowFocus, coWrapCaption, coEditable]
+            Position = 0
+            Text = 'Attributes'
+            Width = 102
+            PropertyName = 'attributes'
+            ReadOnly = True
+          end        
+          item
+            Options = [coAllowClick, coDraggable, coEnabled, coParentBidiMode, coParentColor, coResizable, coShowDropMark, coVisible, coAllowFocus, coWrapCaption, coEditable]
+            Position = 1
+            Tag = 1
+            Text = 'Values'
+            Width = 282
+            PropertyName = 'values'
+            ReadOnly = True
+          end>
+        Header.DefaultHeight = 18
+        Header.Height = 28
+        Header.MainColumn = 1
+        Header.MaxHeight = 100
+        Header.MinHeight = 18
+        Header.Options = [hoColumnResize, hoDblClickResize, hoDrag, hoShowSortGlyphs, hoVisible, hoHeaderClickAutoSort]
+        Header.SortColumn = 0
+        Header.Style = hsFlatButtons
+        PopupMenu = PopupMenu1
+        TabOrder = 0
+        SelectedAndTotalLabel = Label1
+        TreeOptions.MiscOptions = [toFullRepaintOnResize, toGridExtensions, toInitOnSave, toReadOnly, toVariableNodeHeight, toFullRowDrag, toEditOnClick]
+        TreeOptions.SelectionOptions = [toDisableDrawSelection, toExtendedFocus, toMultiSelect, toRightClickSelect, toSimpleDrawSelection]
+        ZebraColor = 15593713
+        PopupMenuOptions = [pmoShowFind, pmoShowFindNext]
+        FilterOptions.CaseInsensitive = True
+        OnMouseDown = GridAttributesMouseDown
+      end
     end
-  end
-  object Splitter2: TSplitter
-    AnchorSideLeft.Side = asrBottom
-    Left = 377
-    Height = 324
-    Top = 28
-    Width = 5
-    Align = alRight
-    ResizeAnchor = akRight
-    Visible = False
+    object Splitter2: TSplitter
+      AnchorSideLeft.Side = asrBottom
+      Left = 210
+      Height = 316
+      Top = 33
+      Width = 5
+      Align = alRight
+      ResizeAnchor = akRight
+      Visible = False
+    end
   end
   object ActionList_ADUC: TActionList
     Images = CoreDataModule.ImageList1

--- a/packages/OpenRSATGUI/ufrmmoduleaduc.lfm
+++ b/packages/OpenRSATGUI/ufrmmoduleaduc.lfm
@@ -169,6 +169,12 @@ object FrmModuleADUC: TFrmModuleADUC
         Action = Action_ShowRelationShip
         Caption = 'Show group relation'
       end
+      object ToolButton_AttributesGrid: TToolButton
+        Left = 385
+        Top = 2
+        ImageIndex = 57
+        OnClick = ToolButton_AttributesGridClick
+      end
     end
     object Image1: TImage
       Left = 689
@@ -423,6 +429,7 @@ object FrmModuleADUC: TFrmModuleADUC
     ClientWidth = 170
     TabOrder = 1
     object TreeADUC: TTreeView
+      AnchorSideTop.Control = TisSearchEdit_TreeADUC
       Left = 0
       Height = 314
       Top = 31
@@ -465,6 +472,9 @@ object FrmModuleADUC: TFrmModuleADUC
     end
   end
   object Panel2: TPanel
+    AnchorSideLeft.Control = Splitter1
+    AnchorSideLeft.Side = asrBottom
+    AnchorSideRight.Control = Splitter2
     Left = 175
     Height = 349
     Top = 28
@@ -530,6 +540,7 @@ object FrmModuleADUC: TFrmModuleADUC
       OnDragDrop = GridADUCDragDrop
       OnEdited = GridADUCEdited
       OnEndDrag = GridADUCEndDrag
+      OnFocusChanged = GridADUCFocusChanged
       OnGetImageIndex = GridADUCGetImageIndex
       OnKeyDown = GridADUCKeyDown
       OnKeyPress = GridADUCKeyPress
@@ -574,6 +585,78 @@ object FrmModuleADUC: TFrmModuleADUC
         OnChange = CheckBox_IncludeSubContainerChange
       end
     end
+  end
+  object Panel5: TPanel
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
+    Left = 629
+    Height = 291
+    Top = 61
+    Width = 410
+    Align = alRight
+    BorderSpacing.Top = 33
+    BorderSpacing.Right = 4
+    BorderSpacing.Bottom = 4
+    BevelOuter = bvNone
+    ClientHeight = 291
+    ClientWidth = 410
+    TabOrder = 4
+    Visible = False
+    object GridAttributes: TTisGrid
+      AnchorSideRight.Side = asrBottom
+      Left = 0
+      Height = 287
+      Top = 0
+      Width = 410
+      Align = alClient
+      BorderSpacing.Bottom = 4
+      Header.AutoSizeIndex = -1
+      Header.Columns = <      
+        item
+          Options = [coAllowClick, coDraggable, coEnabled, coParentBidiMode, coParentColor, coResizable, coShowDropMark, coVisible, coAllowFocus, coWrapCaption, coEditable]
+          Position = 0
+          Text = 'Attributes'
+          Width = 102
+          PropertyName = 'attributes'
+          ReadOnly = True
+        end      
+        item
+          Options = [coAllowClick, coDraggable, coEnabled, coParentBidiMode, coParentColor, coResizable, coShowDropMark, coVisible, coAllowFocus, coWrapCaption, coEditable]
+          Position = 1
+          Tag = 1
+          Text = 'Values'
+          Width = 282
+          PropertyName = 'values'
+          ReadOnly = True
+        end>
+      Header.DefaultHeight = 18
+      Header.Height = 28
+      Header.MainColumn = 1
+      Header.MaxHeight = 100
+      Header.MinHeight = 18
+      Header.Options = [hoColumnResize, hoDblClickResize, hoDrag, hoShowSortGlyphs, hoVisible, hoHeaderClickAutoSort]
+      Header.SortColumn = 0
+      Header.Style = hsFlatButtons
+      PopupMenu = PopupMenu1
+      TabOrder = 0
+      SelectedAndTotalLabel = Label1
+      TreeOptions.MiscOptions = [toFullRepaintOnResize, toGridExtensions, toInitOnSave, toReadOnly, toVariableNodeHeight, toFullRowDrag, toEditOnClick]
+      TreeOptions.SelectionOptions = [toDisableDrawSelection, toExtendedFocus, toMultiSelect, toRightClickSelect, toSimpleDrawSelection]
+      ZebraColor = 15593713
+      PopupMenuOptions = [pmoShowFind, pmoShowFindNext]
+      FilterOptions.CaseInsensitive = True
+      OnMouseDown = GridAttributesMouseDown
+    end
+  end
+  object Splitter2: TSplitter
+    AnchorSideLeft.Side = asrBottom
+    Left = 377
+    Height = 324
+    Top = 28
+    Width = 5
+    Align = alRight
+    ResizeAnchor = akRight
+    Visible = False
   end
   object ActionList_ADUC: TActionList
     Images = CoreDataModule.ImageList1

--- a/packages/OpenRSATGUI/ufrmmoduleaduc.lrj
+++ b/packages/OpenRSATGUI/ufrmmoduleaduc.lrj
@@ -21,6 +21,8 @@
 {"hash":376933,"name":"tfrmmoduleaduc.gridaduc.header.columns[1].text","sourcebytes":[84,121,112,101],"value":"Type"},
 {"hash":156067838,"name":"tfrmmoduleaduc.gridaduc.header.columns[2].text","sourcebytes":[68,101,115,99,114,105,112,116,105,111,110],"value":"Description"},
 {"hash":112186354,"name":"tfrmmoduleaduc.checkbox_includesubcontainer.caption","sourcebytes":[73,110,99,108,117,100,101,32,115,117,98,99,111,110,116,97,105,110,101,114],"value":"Include subcontainer"},
+{"hash":150815091,"name":"tfrmmoduleaduc.gridattributes.header.columns[0].text","sourcebytes":[65,116,116,114,105,98,117,116,101,115],"value":"Attributes"},
+{"hash":97008579,"name":"tfrmmoduleaduc.gridattributes.header.columns[1].text","sourcebytes":[86,97,108,117,101,115],"value":"Values"},
 {"hash":146640072,"name":"tfrmmoduleaduc.action_refresh.caption","sourcebytes":[82,101,102,114,101,115,104],"value":"Refresh"},
 {"hash":114087587,"name":"tfrmmoduleaduc.action_properties.caption","sourcebytes":[80,114,111,112,101,114,116,105,101,115],"value":"Properties"},
 {"hash":211143810,"name":"tfrmmoduleaduc.action_newuser.caption","sourcebytes":[78,101,119,32,85,115,101,114],"value":"New User"},

--- a/packages/OpenRSATGUI/ufrmmoduleaduc.pas
+++ b/packages/OpenRSATGUI/ufrmmoduleaduc.pas
@@ -166,22 +166,26 @@ type
     Panel2: TPanel;
     Panel3: TPanel;
     Panel4: TPanel;
+    Panel5: TPanel;
     PopupMenu1: TPopupMenu;
     SelectDirectoryDialog1: TSelectDirectoryDialog;
     Separator1: TMenuItem;
     Separator2: TMenuItem;
     Separator4: TMenuItem;
+    Splitter2: TSplitter;
     Timer_TreeChangeNode: TTimer;
     Timer_SearchInGrid: TTimer;
     Label1: TLabel;
     MenuItem_Search: TMenuItem;
     Splitter1: TSplitter;
     GridADUC: TTisGrid;
+    GridAttributes: TTisGrid;
     TisGridHeaderPopupMenu1: TTisGridHeaderPopupMenu;
     TisSearchEdit_TreeADUC: TTisSearchEdit;
     TisSearchEdit_GridADUC: TTisSearchEdit;
     ToolBar1: TToolBar;
     ToolButton1: TToolButton;
+    ToolButton_AttributesGrid: TToolButton;
     ToolButton_ShowRelation: TToolButton;
     ToolButton_AddToGroup: TToolButton;
     ToolButton_Copy: TToolButton;
@@ -257,20 +261,22 @@ type
     procedure Action_TaskResetPasswordExecute(Sender: TObject);
     procedure Action_TaskResetPasswordUpdate(Sender: TObject);
     procedure CheckBox_IncludeSubContainerChange(Sender: TObject);
-    procedure GridADUCKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState
-      );
+    procedure GridADUCFocusChanged(Sender: TBaseVirtualTree; Node: PVirtualNode; Column: TColumnIndex);
+    procedure GridADUCKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure GridAttributesMouseDown(Sender: TObject; Button: TMouseButton; 
+      Shift: TShiftState; X, Y: Integer);
     procedure MenuItem_EditColumnsClick(Sender: TObject);
     procedure Timer_SearchInGridTimer(Sender: TObject);
     procedure Timer_TreeChangeNodeTimer(Sender: TObject);
     procedure TisSearchEdit_TreeADUCSearch(Sender: TObject; const aText: string);
     procedure TisSearchEdit_GridADUCSearch(Sender: TObject; const aText: string);
+    procedure ToolButton_AttributesGridClick(Sender: TObject);
     procedure TreeADUCChange(Sender: TObject; Node: TTreeNode);
     procedure TreeADUCContextPopup(Sender: TObject; MousePos: TPoint; var Handled: Boolean);
     procedure TreeADUCCreateNodeClass(Sender: TCustomTreeView;
       var NodeClass: TTreeNodeClass);
     procedure TreeADUCDragDrop(Sender, Source: TObject; X, Y: Integer);
-    procedure TreeADUCDragOver(Sender, Source: TObject; X, Y: Integer;
-      State: TDragState; var Accept: Boolean);
+    procedure TreeADUCDragOver(Sender, Source: TObject; X, Y: Integer; State: TDragState; var Accept: Boolean);
     procedure TreeADUCEndDrag(Sender, Target: TObject; X, Y: Integer);
     procedure TreeADUCExpanded(Sender: TObject; Node: TTreeNode);
     procedure TreeADUCGetImageIndex(Sender: TObject; Node: TTreeNode);
@@ -1524,6 +1530,50 @@ begin
   UpdateGridADUC(nil);
 end;
 
+procedure TFrmModuleADUC.GridADUCFocusChanged(Sender: TBaseVirtualTree;
+  Node: PVirtualNode; Column: TColumnIndex);
+var
+  OnSearch: TNotifyEvent;
+  NewRow: TDocVariantData;
+  VariantData: PDocVariantData;
+  LdapResult: TLdapResult;
+  a: TLdapAttribute;
+  value: RawUtf8;
+begin
+  NewRow.Init();
+  VariantData := GridADUC.GetNodeAsPDocVariantData(Node, True);
+  GridAttributes.Clear;
+  GridAttributes.BeginUpdate;
+  OnSearch := FrmRSAT.LdapClient.OnSearch;
+  try
+    FrmRSAT.LdapClient.OnSearch := nil;
+    if Assigned(VariantData) then
+    begin
+      LdapResult := FrmRSAT.LdapClient.SearchObject(VariantData^.S['objectName'], '', ['*']);
+      if not Assigned(LdapResult) then
+         exit;
+
+      for a in LdapResult.Attributes.Items do
+      begin
+        if not Assigned(a) then
+          continue;
+        
+        NewRow.AddValue('attributes', a.AttributeName); 
+        for value in a.GetAllReadable() do
+        begin
+          NewRow.AddOrUpdateValue('values', value);
+          GridAttributes.Data.AddItem(NewRow);
+        end;
+        NewRow.Clear
+      end;
+    end;
+    finally
+      GridAttributes.EndUpdate;
+      FrmRSAT.LdapClient.OnSearch := OnSearch;
+      GridAttributes.LoadData();
+  end;
+end;
+
 procedure TFrmModuleADUC.GridADUCKeyDown(Sender: TObject; var Key: Word;
   Shift: TShiftState);
 begin
@@ -1533,6 +1583,13 @@ begin
     GridADUC.EditNode(GridADUC.FocusedNode, GridADUC.FocusedColumn);
     GridADUC.TreeOptions.MiscOptions := GridADUC.TreeOptions.MiscOptions + [toReadOnly] - [toEditable];
   end;
+end;
+
+procedure TFrmModuleADUC.GridAttributesMouseDown(Sender: TObject; 
+  Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
+begin
+  if Button = mbLeft then
+    GridAttributes.BeginDrag(False);
 end;
 
 procedure TFrmModuleADUC.MenuItem_EditColumnsClick(Sender: TObject);
@@ -1616,6 +1673,20 @@ procedure TFrmModuleADUC.TisSearchEdit_GridADUCSearch(Sender: TObject;
   const aText: string);
 begin
   UpdateGridADUC(nil);
+end;
+
+procedure TFrmModuleADUC.ToolButton_AttributesGridClick(Sender: TObject);
+begin
+  if Panel5.Visible then
+  begin
+    Splitter2.Visible := False;
+    Panel5.Visible := False;
+  end
+  else
+  begin
+    Panel5.Visible := True;
+    Splitter2.Visible := True;
+  end;
 end;
 
 procedure TFrmModuleADUC.TreeADUCChange(Sender: TObject; Node: TTreeNode);
@@ -1914,39 +1985,64 @@ var
   BaseDN, oldDN, newDN: String;
   Node: PVirtualNode;
   newDNS, oldDNS: Array of String;
+  NewColName: RawUtf8;
 begin
   oldDNS := [];
   newDNS := [];
 
   if Assigned(fLog) then
     fLog.Log(sllTrace, '% - DragDrop', [Self.Name]);
-
-  GridADUC.GetHitTestInfoAt(Pt.x, Pt.y, True, HitInfo);
-
-  Data := GridADUC.GetNodeAsPDocVariantData(HitInfo.HitNode);
-  BaseDN := Data^.U['objectName'];
-
-  Node := GridADUC.GetFirstSelected();
-  if not Assigned(Node) then
+  
+  if Source = GridADUC then
   begin
+    GridADUC.GetHitTestInfoAt(Pt.x, Pt.y, True, HitInfo);
+  
+    Data := GridADUC.GetNodeAsPDocVariantData(HitInfo.HitNode);
+    BaseDN := Data^.U['objectName'];
+  
+    Node := GridADUC.GetFirstSelected();
+    if not Assigned(Node) then
+    begin
+      if Assigned(fLog) then
+        fLog.Log(sllWarning, '% - No selected node.', [Self.Name]);
+      Exit;
+    end;
+  
+    repeat
+      Data := GridADUC.GetNodeAsPDocVariantData(Node);
+      oldDN := data^.U['objectName'];
+      newDN := String.Join(',', [oldDN.split(',')[0], BaseDN]);
+      Insert(newDN, newDNS, Length(newDNS));
+      Insert(oldDN, oldDNS, Length(oldDNS));
+      Node := GridADUC.GetNextSelected(Node);
+    until Node = nil;
+  
+    FrmRSAT.LdapClient.MoveLdapEntries(oldDNS, newDNS);
     if Assigned(fLog) then
-      fLog.Log(sllWarning, '% - No selected node.', [Self.Name]);
-    Exit;
+      fLog.Log(sllInfo, '% - % entries moved.', [Self.Name, IntToStr(Length(oldDNS))]);
+    Action_Refresh.Execute;
+  end
+  else if Source = GridAttributes then
+  begin
+    Node := GridAttributes.GetFirstSelected();
+    if not Assigned(Node) then
+    begin
+      if Assigned(fLog) then
+        fLog.Log(sllWarning, '% - No selected node.', [Self.Name]);
+      Exit;
+    end;
+
+    Data := GridAttributes.GetNodeAsPDocVariantData(Node);
+    NewColName := Data^.S['attributes'];
+    if NewColName = '' then
+       exit;
+
+    if not fModuleAduc.ADUCOption.GridAttributesFilter.Contains(NewColName) then
+    begin
+       fModuleAduc.ADUCOption.GridAttributesFilter.Append(NewColName);
+       UpdateGridADUC(nil);
+    end;
   end;
-
-  repeat
-    Data := GridADUC.GetNodeAsPDocVariantData(Node);
-    oldDN := data^.U['objectName'];
-    newDN := String.Join(',', [oldDN.split(',')[0], BaseDN]);
-    Insert(newDN, newDNS, Length(newDNS));
-    Insert(oldDN, oldDNS, Length(oldDNS));
-    Node := GridADUC.GetNextSelected(Node);
-  until Node = nil;
-
-  FrmRSAT.LdapClient.MoveLdapEntries(oldDNS, newDNS);
-  if Assigned(fLog) then
-    fLog.Log(sllInfo, '% - % entries moved.', [Self.Name, IntToStr(Length(oldDNS))]);
-  Action_Refresh.Execute;
 end;
 
 procedure TFrmModuleADUC.GridADUCDragOver(Sender: TBaseVirtualTree;
@@ -1957,19 +2053,26 @@ var
   Data: PDocVariantData;
 begin
   Accept := False;
-  if (Source <> GridADUC) then
-    Exit;
 
-  GridADUC.TreeOptions.PaintOptions := GridADUC.TreeOptions.PaintOptions + [toHotTrack];
-  HitInfo.HitNode := nil;
-  GridADUC.GetHitTestInfoAt(Pt.x, Pt.y, True, HitInfo);
-  if not Assigned(HitInfo.HitNode) or (hiNowhere in HitInfo.HitPositions) then
-    Exit;
-  Data := GridADUC.GetNodeAsPDocVariantData(HitInfo.HitNode);
-  if not Assigned(data) then
-    Exit;
-  if TRawUtf8DynArrayContains(Data^.A['objectClass']^.ToRawUtf8DynArray, 'organizationalUnit') then
-    Accept := HitInfo.HitNode <> GridADUC.FocusedNode;
+  if Source = GridADUC then
+  begin
+    // Drag n'Drop from GridADUC
+    GridADUC.TreeOptions.PaintOptions := GridADUC.TreeOptions.PaintOptions + [toHotTrack];
+    HitInfo.HitNode := nil;
+    GridADUC.GetHitTestInfoAt(Pt.x, Pt.y, True, HitInfo);
+    if not Assigned(HitInfo.HitNode) or (hiNowhere in HitInfo.HitPositions) then
+      Exit;
+    Data := GridADUC.GetNodeAsPDocVariantData(HitInfo.HitNode);
+    if not Assigned(data) then
+      Exit;
+    if TRawUtf8DynArrayContains(Data^.A['objectClass']^.ToRawUtf8DynArray, 'organizationalUnit') then
+      Accept := HitInfo.HitNode <> GridADUC.FocusedNode;
+  end
+  else if Source = GridAttributes then
+  begin
+    // Drag n'Drop from GridAttributes
+    Accept := True;
+  end;
 end;
 
 procedure TFrmModuleADUC.GridADUCEdited(Sender: TBaseVirtualTree;
@@ -2510,6 +2613,10 @@ var
   Columns: TRawUtf8DynArray;
   i: Integer;
   NewColumn: TTisGridColumn;
+  item: TLdapResult;
+  a: TLdapAttribute;
+  OnSearch: TNotifyEvent;
+  Filter: RawUtf8;
 begin
   Columns := fModuleAduc.ADUCOption.GridAttributesFilter;
 
@@ -2519,11 +2626,40 @@ begin
     else
       Columns.Remove(Columns.IndexOf(TTisGridColumn(GridADUC.Header.Columns[i]).PropertyName));
 
+  Filter := '';
   for i := 0 to Pred(Length(Columns)) do
   begin
     NewColumn := TTisGridColumn(GridADUC.Header.Columns.Add);
+    NewColumn.Width := 150;
     NewColumn.PropertyName := Columns[i];
-    NewColumn.DisplayName := Columns[i];
+    Filter := FormatUtf8('%(lDAPDisplayName=%)', [Filter, Columns[i]]);  
+  end;
+  if Filter = '' then
+    Exit;
+  Filter := FormatUtf8('(|%)', [Filter]);
+  
+  try  
+    OnSearch := FrmRSAT.LdapClient.OnSearch;
+    FrmRSAT.LdapClient.OnSearch := nil;
+    if not FrmRSAT.LdapClient.Search(FrmRSAT.LdapClient.SchemaDN, False, Filter, ['lDAPDisplayName', 'name']) then
+       exit;
+
+    for item in FrmRSAT.LdapClient.SearchResult.Items do
+    begin
+      if not Assigned(item) then
+        continue;
+
+      for a in item.Attributes.Items do
+      begin
+        if not Assigned(a) then
+           continue;
+
+        if a.AttributeName = 'name' then
+           NewColumn.Text := a.GetReadable();
+      end;
+    end;
+  finally
+    FrmRSAT.LdapClient.OnSearch := OnSearch;
   end;
 end;
 


### PR DESCRIPTION
### Introduce Attribute Grid in Module ADUC

**[UPD] ModuleADUC - Add basic attributes panel next to ADUC grid**
**[UPD] ModuleADUC - Display attributes list in the grid depending selected resource**
**[NEW] ModuleADUC- Add a TToggleButton to display the attributes grid or not**
Implementation of a _TTisGrid_ next to _GridADUC_ listing every attributes owned by each element. This grid is hidden by default but can be displayed clicking on a _TToggleButton_ located in the toolbar.


**[NEW] ModuleADUC - Implement base of drag n'drop from GridAttributes to GridADUC**
**[UPD] ModuleADUC - Fill GridADUC new column with correct values**
**[UPD] ModuleADUC - Replace the default column name by the correctname from ldap**
Introduce drag n'drop from previously implemented Attributes grid to _GridADUC_. When an element is dropped on the _GridADUC_, an new column appears if this column doesn't exist in the current grid.