### PR TITLE
perf(search): use indexed logon attribute filters

### DIFF
--- a/packages/OpenRSATGUI/uvissearch.pas
+++ b/packages/OpenRSATGUI/uvissearch.pas
@@ -353,9 +353,12 @@ begin
   case PageControl_Search.ActivePageIndex of
     0:
     begin
-      Filter := Trim(Edit_BasicValue.Text);
+      Filter := LdapEscape(Trim(Edit_BasicValue.Text));
       if not (Filter = '') then
-        Filter := FormatUtf8('|(cn=*%*)(dn=*%*)(name=*%*)(userPrincipalName=*%*)', [Filter, Filter, Filter, Filter])
+        // Keep the legacy contains search for display names, but use indexed
+        // prefix matching for logon attributes to avoid slow full subtree scans
+        // on large directories.
+        Filter := FormatUtf8('|(cn=*%*)(dn=*%*)(name=*%*)(sAMAccountName=%*)(userPrincipalName=%*)', [Filter, Filter, Filter, Filter, Filter])
       else
         Filter := 'name=*';
     end;

--- a/packages/OpenRSATGUI/uvissearch.pas
+++ b/packages/OpenRSATGUI/uvissearch.pas
@@ -353,12 +353,11 @@ begin
   case PageControl_Search.ActivePageIndex of
     0:
     begin
-      Filter := LdapEscape(Trim(Edit_BasicValue.Text));
-      if not (Filter = '') then
-        // Keep the legacy contains search for display names, but use indexed
-        // prefix matching for logon attributes to avoid slow full subtree scans
-        // on large directories.
-        Filter := FormatUtf8('|(cn=*%*)(dn=*%*)(name=*%*)(sAMAccountName=%*)(userPrincipalName=%*)', [Filter, Filter, Filter, Filter, Filter])
+      Filter := Trim(Edit_BasicValue.Text);
+      if (Filter <> '') then
+        // https://ldapwiki.com/wiki/Wiki.jsp?page=Ambiguous%20Name%20Resolution
+        // Ambiguous Name Resolution (aNR) is a search algorithm in Microsoft Active Directory that permits a client to search multiple Naming Attributes on objects via a single clause in a search filter
+        Filter := FormatUtf8('(anr=%*)', [LdapEscape(Filter)])
       else
         Filter := 'name=*';
     end;

--- a/sources/version.inc
+++ b/sources/version.inc
@@ -1,2 +1,2 @@
 const
-  VERSION = '0.4.291';
+  VERSION = '0.4.310';


### PR DESCRIPTION
Escape basic search input and add prefix matching on sAMAccountName and userPrincipalName to speed up Active Directory searches while preserving contains matching for display-name fields.