### PR TITLE
[FIX] ModuleADSS - Make new site link page works

### DIFF
--- a/packages/OpenRSATCore/OpenRSATCore.lpk
+++ b/packages/OpenRSATCore/OpenRSATCore.lpk
@@ -112,6 +112,10 @@
         <Filename Value="uviewkeytabpresenter.pas"/>
         <UnitName Value="uviewkeytabpresenter"/>
       </Item>
+      <Item>
+        <Filename Value="unewsitelink.pas"/>
+        <UnitName Value="unewsitelink"/>
+      </Item>
     </Files>
     <i18n>
       <EnableI18N Value="True"/>

--- a/packages/OpenRSATCore/OpenRSATCore.pas
+++ b/packages/OpenRSATCore/OpenRSATCore.pas
@@ -8,10 +8,12 @@ unit OpenRSATCore;
 interface
 
 uses
-  uhelpers, ursatldapclient, ucommon, uldapconfigs, uconfig, uoption, umodule, umoduleaducoption, umoduleaduc, ursat, 
-  ursatoption, umoduleadssoption, umoduleadss, umoduleaddns, umoduleaddnsoption, umoduleadsi, umoduleadsioption, udns, 
-  ugplink, uproperty, usidcache, uadvancedsecuritypresenter, uguidcache, uselectobjectguidpresenter, 
-  uviewkeytabpresenter, LazarusPackageIntf;
+  uhelpers, ursatldapclient, ucommon, uldapconfigs, uconfig, uoption, umodule, 
+  umoduleaducoption, umoduleaduc, ursat, ursatoption, umoduleadssoption, 
+  umoduleadss, umoduleaddns, umoduleaddnsoption, umoduleadsi, 
+  umoduleadsioption, udns, ugplink, uproperty, usidcache, 
+  uadvancedsecuritypresenter, uguidcache, uselectobjectguidpresenter, 
+  uviewkeytabpresenter, unewsitelink, LazarusPackageIntf;
 
 implementation
 

--- a/packages/OpenRSATCore/languages/ucommon.el.po
+++ b/packages/OpenRSATCore/languages/ucommon.el.po
@@ -951,6 +951,10 @@ msgstr "Επιλέξτε νέο Διαχειριστή"
 msgid "Select owner"
 msgstr "Επιλέξτε ιδιοκτήτη"
 
+#: ucommon.rstoofewsitesavailableforsitelink
+msgid "Active Directory Sites and Services cannot locate two sites to create a working site link object. You may create a new site link that links only one site, but it will have no effect until it links at least two sites."
+msgstr ""
+
 #: ucommon.rstuesday
 msgid "Tuesday"
 msgstr "Τρίτη"

--- a/packages/OpenRSATCore/languages/ucommon.en.po
+++ b/packages/OpenRSATCore/languages/ucommon.en.po
@@ -968,6 +968,10 @@ msgstr "Select new Manager"
 msgid "Select owner"
 msgstr "Select owner"
 
+#: ucommon.rstoofewsitesavailableforsitelink
+msgid "Active Directory Sites and Services cannot locate two sites to create a working site link object. You may create a new site link that links only one site, but it will have no effect until it links at least two sites."
+msgstr "Active Directory Sites and Services cannot locate two sites to create a working site link object. You may create a new site link that links only one site, but it will have no effect until it links at least two sites."
+
 #: ucommon.rstuesday
 msgid "Tuesday"
 msgstr "Tuesday"

--- a/packages/OpenRSATCore/languages/ucommon.fr.po
+++ b/packages/OpenRSATCore/languages/ucommon.fr.po
@@ -968,6 +968,10 @@ msgstr "Sélectionner un nouveau gestionnaire"
 msgid "Select owner"
 msgstr "Sélectionner un propriétaire"
 
+#: ucommon.rstoofewsitesavailableforsitelink
+msgid "Active Directory Sites and Services cannot locate two sites to create a working site link object. You may create a new site link that links only one site, but it will have no effect until it links at least two sites."
+msgstr "Active Directory Sites and Services n'a pas pu localiser deux sites pour créer un lien fonctionnel. Vous pouvez créer un nouveau lien lié à un seul site, cependant, celui-ci n'aura aucun effet tant qu'il ne liera pas deux sites."
+
 #: ucommon.rstuesday
 msgid "Tuesday"
 msgstr "Mardi"

--- a/packages/OpenRSATCore/languages/ucommon.pot
+++ b/packages/OpenRSATCore/languages/ucommon.pot
@@ -950,6 +950,10 @@ msgstr ""
 msgid "Select owner"
 msgstr ""
 
+#: ucommon.rstoofewsitesavailableforsitelink
+msgid "Active Directory Sites and Services cannot locate two sites to create a working site link object. You may create a new site link that links only one site, but it will have no effect until it links at least two sites."
+msgstr ""
+
 #: ucommon.rstuesday
 msgid "Tuesday"
 msgstr ""

--- a/packages/OpenRSATCore/ucommon.pas
+++ b/packages/OpenRSATCore/ucommon.pas
@@ -179,6 +179,8 @@ resourcestring
 
   rsLdapMoveWarningMessage = 'Moving objects in Active Directory Domain Services can prevent your existing system from working the way it was designed. For exemple, moving an organizational unit (OU) can affect the way that group policies are applied to the accounts within the OU.' + LineEnding +
   'Are you sure you want to move this object?';
+  
+  rsTooFewSitesAvailableForSiteLink = 'Active Directory Sites and Services cannot locate two sites to create a working site link object. You may create a new site link that links only one site, but it will have no effect until it links at least two sites.';
 
   // Well Known Sid
   rsWellKnownSidNull = '';

--- a/packages/OpenRSATCore/unewsitelink.pas
+++ b/packages/OpenRSATCore/unewsitelink.pas
@@ -73,7 +73,7 @@ begin
   
   ListLen := Length(List);
   SetLength(List, ListLen + 1);
-  List[ListLen] := Item;
+  List[ListLen] := TLdapResult(Item.Clone);
 end;
 
 function TNewSiteLinkPresenter.SearchSitesInLdap: boolean;

--- a/packages/OpenRSATCore/unewsitelink.pas
+++ b/packages/OpenRSATCore/unewsitelink.pas
@@ -30,6 +30,7 @@ type
 
   public
     constructor Create(ALdap: TRsatLdapClient);
+    destructor Destroy; override;
 
     procedure GetAllSites;
     procedure MoveItemToInSite(Index: Integer);
@@ -53,7 +54,11 @@ begin
   fLdap := ALdap;
 end;
 
-{ PRIVATE }
+destructor TNewSiteLinkPresenter.Destroy;
+begin
+  inherited Destroy;
+end;
+
 procedure TNewSiteLinkPresenter.RemoveItemFromArray(var List: TLdapResultArray; Index: Integer);
 var
   i: Integer;
@@ -78,10 +83,9 @@ end;
 
 function TNewSiteLinkPresenter.SearchSitesInLdap: boolean;
 begin
-  Result := fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, FormatUtf8('(&(objectClass=site))', []), ['name', 'distinguishedName'])
+  Result := fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, FormatUtf8('(&(objectClass=site))', []), ['name', 'distinguishedName']);
 end;
 
-{ PUBLIC }
 procedure TNewSiteLinkPresenter.MoveItemToInSite(Index: Integer);
 begin
   SetLength(fInSite, Length(fInSite) + 1);
@@ -147,7 +151,7 @@ var
   DN: RawUtf8;
   AttrList: TLdapAttributeList;
   Attr: TLdapAttribute;
-  i: Integer;
+  i, n: Integer;
 begin
   Result := False;
   DN := FormatUtf8('CN=%,CN=SMTP,CN=Inter-Site Transports,CN=Sites,%', [Name, fLdap.ConfigDN]);
@@ -166,6 +170,10 @@ begin
     Result := fLdap.Add(DN, AttrList);
   finally
     AttrList.Free;
+    for n := 0 to High(fInSite) do
+      FreeAndNil(fInSite[n]);
+    for n := 0 to High(fNotInSite) do
+      FreeAndNil(fNotInSite[n]);
   end;
 end;
 

--- a/packages/OpenRSATCore/unewsitelink.pas
+++ b/packages/OpenRSATCore/unewsitelink.pas
@@ -1,0 +1,173 @@
+unit unewsitelink;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes,
+  SysUtils,
+  mormot.core.base,
+  mormot.core.text,
+  mormot.net.ldap,
+  ursatldapclient;
+
+type
+
+  { Ldap Result }
+  TLdapResultArray = array of TLdapResult;
+
+  { TNewSiteLinkPresenter }
+  TNewSiteLinkPresenter = class
+  private
+    fLdap: TRsatLdapClient;
+    fInSite, fNotInSite: TLdapResultArray;
+    
+    procedure RemoveItemFromArray(var List: TLdapResultArray; Index: Integer);
+    procedure AddItemInResultArray(var List: TLdapResultArray; Item: TLdapResult);
+
+    function SearchSitesInLdap: boolean;
+
+  public
+    constructor Create(ALdap: TRsatLdapClient);
+
+    procedure GetAllSites;
+    procedure MoveItemToInSite(Index: Integer);
+    procedure MoveItemToNotInSite(Index: Integer);
+
+    function GetSitesInSiteLink: TLdapResultArray;
+    function GetSitesNotInSiteLink: TLdapResultArray;
+    function GetResultName(Obj: TLdapResult): RawUtf8;
+    function GetSiteAttrValue(List: TLdapResultArray; idx: Integer; attr: RawUtf8): RawUtf8;
+    function GetNbSites: Integer;
+    function CanCreateSiteLink(const Name: RawUtf8): Boolean;
+    function CreateSiteLink(const Name: RawUtf8): Boolean;
+
+    property Ldap: TRsatLdapClient read fLdap;
+  end;
+
+implementation
+
+constructor TNewSiteLinkPresenter.Create(ALdap: TRsatLdapClient);
+begin
+  fLdap := ALdap;
+end;
+
+{ PRIVATE }
+procedure TNewSiteLinkPresenter.RemoveItemFromArray(var List: TLdapResultArray; Index: Integer);
+var
+  i: Integer;
+begin
+  for i := Index to High(List) - 1 do
+    List[i] := List[i + 1];
+
+  SetLength(List, Length(List) - 1);
+end;
+
+procedure TNewSiteLinkPresenter.AddItemInResultArray(var List: TLdapResultArray; Item: TLdapResult);
+var
+  ListLen: Integer;
+begin
+  if not Assigned(Item) then
+    exit;
+  
+  ListLen := Length(List);
+  SetLength(List, ListLen + 1);
+  List[ListLen] := Item;
+end;
+
+function TNewSiteLinkPresenter.SearchSitesInLdap: boolean;
+begin
+  Result := fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, FormatUtf8('(&(objectClass=site))', []), ['name', 'distinguishedName'])
+end;
+
+{ PUBLIC }
+procedure TNewSiteLinkPresenter.MoveItemToInSite(Index: Integer);
+begin
+  SetLength(fInSite, Length(fInSite) + 1);
+  fInSite[High(fInSite)] := fNotInSite[Index];
+  RemoveItemFromArray(fNotInSite, Index);
+end;
+
+procedure TNewSiteLinkPresenter.MoveItemToNotInSite(Index: Integer);
+begin
+  SetLength(fNotInSite, Length(fNotInSite) + 1);
+  fNotInSite[High(fNotInSite)] := fInSite[Index];
+  RemoveItemFromArray(fInSite, Index);
+end;
+
+procedure TNewSiteLinkPresenter.GetAllSites;
+var
+  LdapResult: TLdapResult;
+begin
+  fLdap.SearchBegin();
+  fLdap.SearchScope := lssSingleLevel;
+  repeat
+    if not SearchSitesInLdap then
+      Exit;
+    
+    for LdapResult in fLdap.SearchResult.Items do
+      AddItemInResultArray(fNotInSite, LdapResult);
+  until fLdap.SearchCookie = '';
+  fLdap.SearchEnd;
+end;
+
+function TNewSiteLinkPresenter.GetSitesInSiteLink: TLdapResultArray;
+begin
+  Result := fInSite;
+end;
+
+function TNewSiteLinkPresenter.GetSitesNotInSiteLink: TLdapResultArray;
+begin
+  Result := fNotInSite;
+end;
+
+function TNewSiteLinkPresenter.GetResultName(Obj: TLdapResult): RawUtf8;
+begin
+  Result := Obj.Find('name').GetReadable();
+end;
+
+function TNewSiteLinkPresenter.GetSiteAttrValue(List: TLdapResultArray; idx: Integer; attr: RawUtf8): RawUtf8;
+begin
+  Result := List[idx].Find(attr).GetReadable()
+end;
+
+function TNewSiteLinkPresenter.GetNbSites: Integer;
+begin
+  Result := Length(fInSite) + Length(fNotInSite);
+end;
+
+function TNewSiteLinkPresenter.CanCreateSiteLink(const Name: RawUtf8): Boolean;
+begin
+  Result := (Name <> '') and (Length(fInSite) >= 2);
+end;
+
+function TNewSiteLinkPresenter.CreateSiteLink(const Name: RawUtf8): Boolean;
+var
+  DN: RawUtf8;
+  AttrList: TLdapAttributeList;
+  Attr: TLdapAttribute;
+  i: Integer;
+begin
+  Result := False;
+  DN := FormatUtf8('CN=%,CN=SMTP,CN=Inter-Site Transports,CN=Sites,%', [Name, fLdap.ConfigDN]);
+  AttrList := TLdapAttributeList.Create;
+  try
+    Attr := AttrList.Add('objectClass', 'top');
+    Attr.Add('siteLink');
+    Attr := AttrList.Add('siteList', GetSiteAttrValue(fInSite, 0, 'distinguishedName'));
+
+    for i := 1 to High(fInSite) do
+      Attr.Add(GetSiteAttrValue(fInSite, i, 'distinguishedName'));
+
+    AttrList.Add('cost', '100');
+    AttrList.Add('replInterval', '180');
+
+    Result := fLdap.Add(DN, AttrList);
+  finally
+    AttrList.Free;
+  end;
+end;
+
+end.
+

--- a/packages/OpenRSATCore/unewsitelink.pas
+++ b/packages/OpenRSATCore/unewsitelink.pas
@@ -83,7 +83,7 @@ end;
 
 function TNewSiteLinkPresenter.SearchSitesInLdap: boolean;
 begin
-  Result := fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, FormatUtf8('(&(objectClass=site))', []), ['name', 'distinguishedName']);
+  Result := fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, '(&(objectClass=site))', ['name', 'distinguishedName']);
 end;
 
 procedure TNewSiteLinkPresenter.MoveItemToInSite(Index: Integer);

--- a/packages/OpenRSATGUI/ufrmnewsitelink.lfm
+++ b/packages/OpenRSATGUI/ufrmnewsitelink.lfm
@@ -29,7 +29,7 @@ object FrmNewSiteLink: TFrmNewSiteLink
     object Label_Name: TLabel
       AnchorSideLeft.Control = Panel1
       AnchorSideTop.Control = Panel1
-      Left = 0
+      Left = 8
       Height = 15
       Top = 8
       Width = 35

--- a/packages/OpenRSATGUI/ufrmnewsitelink.pas
+++ b/packages/OpenRSATGUI/ufrmnewsitelink.pas
@@ -106,7 +106,10 @@ end;
 
 procedure TFrmNewSiteLink.Action_NextUpdate(Sender: TObject);
 begin
-  Action_Next.Enabled := (Edit_Name.Text <> '') and (Length(fInSite) >= 2);
+  if Length(fInSite) + Length(fNotInSite) > 2 then
+    Action_Next.Enabled := (Edit_Name.Text <> '') and (Length(fInSite) >= 2)
+  else
+    Action_Next.Enabled := (Edit_Name.Text <> '');
 end;
 
 procedure TFrmNewSiteLink.Button_AddClick(Sender: TObject);
@@ -130,6 +133,9 @@ end;
 procedure TFrmNewSiteLink.ListBox_InSiteLinkSelectionChange(Sender: TObject;
   User: boolean);
 begin
+  if Length(fInSite) + Length(fNotInSite) < 3 then
+    Exit;
+
   Button_Remove.Enabled := True;
   Button_Add.Enabled := False;
 end;
@@ -137,6 +143,9 @@ end;
 procedure TFrmNewSiteLink.ListBox_NotInSiteLinkSelectionChange(Sender: TObject;
   User: boolean);
 begin
+  if Length(fInSite) + Length(fNotInSite) < 3 then
+    Exit;
+
   Button_Add.Enabled := True;
   Button_Remove.Enabled := False;
 end;
@@ -207,8 +216,13 @@ begin
   end;
   
   if n < 1 then
-    MessageDlg('edfer', mtError,[mbOK], 0);
-  
+  begin
+    MessageDlg(rsTooFewSitesAvailableForSiteLink, mtError,[mbOK], 0);
+    SetLength(fInSite, 1);
+    fInSite[0] := fNotInSite[0];
+    SetLength(fNotInSite, 0);
+  end;
+
   if n = 1 then
   begin
     SetLength(fInSite, 2);

--- a/packages/OpenRSATGUI/ufrmnewsitelink.pas
+++ b/packages/OpenRSATGUI/ufrmnewsitelink.pas
@@ -201,21 +201,27 @@ begin
   OwnerNewObject.Image_Object.ImageIndex := Ord(ileADUnknown);
   OwnerNewObject.CallBack := @Load;
 
+  n := 0;
+  fLdap.SearchBegin();
   fLdap.SearchScope := lssSingleLevel;
-  if not fLdap.Search(FormatUtf8('CN=Sites,CN=Configuration,%', [fLdap.DefaultDN()]), false, FormatUtf8('(&(objectClass=site))', []), ['*']) then
-    Exit;
-
-  for Result in fLdap.SearchResult.Items do
-  begin
-    if not Assigned(Result) then
-      continue;
-
-    n := Length(fNotInSite);
-    SetLength(fNotInSite, n + 1);
-    fNotInSite[n] := Result;
-  end;
   
-  if n < 1 then
+  repeat
+    if not fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, FormatUtf8('(&(objectClass=site))', []), ['name', 'distinguishedName']) then
+      Exit;
+    
+    for Result in fLdap.SearchResult.Items do
+    begin
+      if not Assigned(Result) then
+        continue;
+  
+      SetLength(fNotInSite, n + 1);
+      fNotInSite[n] := Result;
+      n += 1;
+    end;
+  until fLdap.SearchCookie = '';
+  fLdap.SearchEnd;
+  
+  if n < 2 then
   begin
     MessageDlg(rsTooFewSitesAvailableForSiteLink, mtError,[mbOK], 0);
     SetLength(fInSite, 1);
@@ -223,7 +229,7 @@ begin
     SetLength(fNotInSite, 0);
   end;
 
-  if n = 1 then
+  if n = 2 then
   begin
     SetLength(fInSite, 2);
     fInSite[0] := fNotInSite[0];

--- a/packages/OpenRSATGUI/ufrmnewsitelink.pas
+++ b/packages/OpenRSATGUI/ufrmnewsitelink.pas
@@ -82,6 +82,7 @@ var
   DistinguishedName: String;
   AttributeList: TLdapAttributeList;
   Attribute: TLdapAttribute;
+  i: Integer;
 begin
   DistinguishedName := Format('CN=%s,CN=SMTP,CN=Inter-Site Transports,CN=Sites,%s', [Edit_Name.Text, fLdap.ConfigDN]);
   AttributeList := TLdapAttributeList.Create;
@@ -90,7 +91,9 @@ begin
     Attribute := AttributeList.Add('objectClass', 'top');
     Attribute.Add('siteLink');
     
-    AttributeList.Add('siteList', '');
+    Attribute := AttributeList.Add('siteList', fInSite[0].Find('distinguishedName').GetReadable());
+    for i := 1 to Length(fInSite) - 1 do
+      Attribute.Add(fInSite[i].Find('distinguishedName').GetReadable());
     
     AttributeList.Add('cost', '100');
     AttributeList.Add('replInterval', '180');

--- a/packages/OpenRSATGUI/ufrmnewsitelink.pas
+++ b/packages/OpenRSATGUI/ufrmnewsitelink.pas
@@ -49,12 +49,16 @@ type
   private
     fLdap: TRsatLdapClient;
 
-    fInSite: TLdapResultArray;
-    fNotInSite: TLdapResultArray;
+    fInSite, fNotInSite: TLdapResultArray;
+    fSitesRetrieved: Integer;
 
     procedure Load;
     procedure LoadListBox;
     procedure MoveItem(var Src, Dest: TLdapResultArray; Index: Integer);
+    procedure GetAllSites;
+
+    function GetName: RawUtf8;
+    function GetSiteAttrValue(List: TLdapResultArray; idx: Integer; attr: RawUtf8): RawUtf8;
   public
     constructor Create(TheOwner: TComponent; ALdap: TRsatLdapClient); reintroduce;
   end;
@@ -79,21 +83,21 @@ end;
 
 procedure TFrmNewSiteLink.Action_NextExecute(Sender: TObject);
 var
-  DistinguishedName: String;
+  DistinguishedName: RawUtf8;
   AttributeList: TLdapAttributeList;
   Attribute: TLdapAttribute;
   i: Integer;
 begin
-  DistinguishedName := Format('CN=%s,CN=SMTP,CN=Inter-Site Transports,CN=Sites,%s', [Edit_Name.Text, fLdap.ConfigDN]);
+  DistinguishedName := Format('CN=%s,CN=SMTP,CN=Inter-Site Transports,CN=Sites,%s', [GetName(), fLdap.ConfigDN]);
   AttributeList := TLdapAttributeList.Create;
 
   try
     Attribute := AttributeList.Add('objectClass', 'top');
     Attribute.Add('siteLink');
     
-    Attribute := AttributeList.Add('siteList', fInSite[0].Find('distinguishedName').GetReadable());
+    Attribute := AttributeList.Add('siteList', GetSiteAttrValue(fInSite, 0, 'distinguishedName'));
     for i := 1 to Length(fInSite) - 1 do
-      Attribute.Add(fInSite[i].Find('distinguishedName').GetReadable());
+      Attribute.Add(GetSiteAttrValue(fInSite, i, 'distinguishedName'));
     
     AttributeList.Add('cost', '100');
     AttributeList.Add('replInterval', '180');
@@ -107,9 +111,9 @@ end;
 procedure TFrmNewSiteLink.Action_NextUpdate(Sender: TObject);
 begin
   if Length(fInSite) + Length(fNotInSite) > 2 then
-    Action_Next.Enabled := (Edit_Name.Text <> '') and (Length(fInSite) >= 2)
+    Action_Next.Enabled := (GetName() <> '') and (Length(fInSite) >= 2)
   else
-    Action_Next.Enabled := (Edit_Name.Text <> '');
+    Action_Next.Enabled := (GetName() <> '');
 end;
 
 procedure TFrmNewSiteLink.Button_AddClick(Sender: TObject);
@@ -182,15 +186,37 @@ begin
   end;
 end;
 
+procedure TFrmNewSiteLink.GetAllSites;
+var
+  LdapResult: TLdapResult;
+begin
+  fLdap.SearchBegin();
+  fLdap.SearchScope := lssSingleLevel;
+  repeat
+    if not fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, FormatUtf8('(&(objectClass=site))', []), ['name', 'distinguishedName']) then
+      Exit;
+    
+    for LdapResult in fLdap.SearchResult.Items do
+    begin
+      if not Assigned(LdapResult) then
+        continue;
+  
+      SetLength(fNotInSite, fSitesRetrieved + 1);
+      fNotInSite[fSitesRetrieved] := LdapResult;
+      fSitesRetrieved += 1;
+    end;
+  until fLdap.SearchCookie = '';
+  fLdap.SearchEnd;
+end;
+
 constructor TFrmNewSiteLink.Create(TheOwner: TComponent; ALdap: TRsatLdapClient);
 var
   OwnerNewObject: TVisNewObject absolute TheOwner;
-  Result: TLdapResult;
-  n: Integer;
 begin
   inherited Create(TheOwner);
 
   fLdap := ALdap;
+  fSitesRetrieved := 0;
 
   OwnerNewObject.Caption := rsNewObjectSiteLink;
   OwnerNewObject.Btn_Next.Action := ActionList.ActionByName('Action_Next');
@@ -200,28 +226,10 @@ begin
   OwnerNewObject.Btn_Back.Visible := False;
   OwnerNewObject.Image_Object.ImageIndex := Ord(ileADUnknown);
   OwnerNewObject.CallBack := @Load;
-
-  n := 0;
-  fLdap.SearchBegin();
-  fLdap.SearchScope := lssSingleLevel;
   
-  repeat
-    if not fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, FormatUtf8('(&(objectClass=site))', []), ['name', 'distinguishedName']) then
-      Exit;
-    
-    for Result in fLdap.SearchResult.Items do
-    begin
-      if not Assigned(Result) then
-        continue;
+  GetAllSites;
   
-      SetLength(fNotInSite, n + 1);
-      fNotInSite[n] := Result;
-      n += 1;
-    end;
-  until fLdap.SearchCookie = '';
-  fLdap.SearchEnd;
-  
-  if n < 2 then
+  if fSitesRetrieved < 2 then
   begin
     MessageDlg(rsTooFewSitesAvailableForSiteLink, mtError,[mbOK], 0);
     SetLength(fInSite, 1);
@@ -229,7 +237,7 @@ begin
     SetLength(fNotInSite, 0);
   end;
 
-  if n = 2 then
+  if fSitesRetrieved = 2 then
   begin
     SetLength(fInSite, 2);
     fInSite[0] := fNotInSite[0];
@@ -238,6 +246,16 @@ begin
   end;
   
   LoadListBox;
+end;
+
+function TFrmNewSiteLink.GetName: RawUtf8;
+begin
+  Result := Edit_Name.Text;
+end;
+
+function TFrmNewSiteLink.GetSiteAttrValue(List: TLdapResultArray; idx: Integer; attr: RawUtf8): RawUtf8;
+begin
+  Result := List[idx].Find(attr).GetReadable()
 end;
 
 end.

--- a/packages/OpenRSATGUI/ufrmnewsitelink.pas
+++ b/packages/OpenRSATGUI/ufrmnewsitelink.pas
@@ -15,7 +15,8 @@ uses
   tis.ui.grid.core,
   mormot.core.base,
   mormot.net.ldap,
-  ursatldapclient;
+  ursatldapclient,
+  unewsitelink;
 
 type
 
@@ -47,18 +48,11 @@ type
   TLdapResultArray = array of TLdapResult;
     
   private
-    fLdap: TRsatLdapClient;
-
-    fInSite, fNotInSite: TLdapResultArray;
-    fSitesRetrieved: Integer;
+    fNewSiteLinkLogic: TNewSiteLinkPresenter;
 
     procedure Load;
     procedure LoadListBox;
-    procedure MoveItem(var Src, Dest: TLdapResultArray; Index: Integer);
-    procedure GetAllSites;
-
     function GetName: RawUtf8;
-    function GetSiteAttrValue(List: TLdapResultArray; idx: Integer; attr: RawUtf8): RawUtf8;
   public
     constructor Create(TheOwner: TComponent; ALdap: TRsatLdapClient); reintroduce;
   end;
@@ -82,131 +76,49 @@ begin
 end;
 
 procedure TFrmNewSiteLink.Action_NextExecute(Sender: TObject);
-var
-  DistinguishedName: RawUtf8;
-  AttributeList: TLdapAttributeList;
-  Attribute: TLdapAttribute;
-  i: Integer;
 begin
-  DistinguishedName := Format('CN=%s,CN=SMTP,CN=Inter-Site Transports,CN=Sites,%s', [GetName(), fLdap.ConfigDN]);
-  AttributeList := TLdapAttributeList.Create;
-
-  try
-    Attribute := AttributeList.Add('objectClass', 'top');
-    Attribute.Add('siteLink');
-    
-    Attribute := AttributeList.Add('siteList', GetSiteAttrValue(fInSite, 0, 'distinguishedName'));
-    for i := 1 to Length(fInSite) - 1 do
-      Attribute.Add(GetSiteAttrValue(fInSite, i, 'distinguishedName'));
-    
-    AttributeList.Add('cost', '100');
-    AttributeList.Add('replInterval', '180');
-    if not fLdap.Add(DistinguishedName, AttributeList) then
-      Exit;
-  finally
-    FreeAndNil(AttributeList);
-  end;
+  fNewSiteLinkLogic.CreateSiteLink(GetName);
 end;
 
 procedure TFrmNewSiteLink.Action_NextUpdate(Sender: TObject);
 begin
-  if Length(fInSite) + Length(fNotInSite) > 2 then
-    Action_Next.Enabled := (GetName() <> '') and (Length(fInSite) >= 2)
-  else
-    Action_Next.Enabled := (GetName() <> '');
+  Action_Next.Enabled := fNewSiteLinkLogic.CanCreateSiteLink(GetName);
 end;
 
 procedure TFrmNewSiteLink.Button_AddClick(Sender: TObject);
-var
-  idx: Integer;
 begin
-  idx := ListBox_NotInSiteLink.ItemIndex;
-  if idx <> -1 then
-    MoveItem(fNotInSite, fInSite, idx);
+  if ListBox_NotInSiteLink.ItemIndex <> -1 then
+  begin
+    fNewSiteLinkLogic.MoveItemToInSite(ListBox_NotInSiteLink.ItemIndex);
+    LoadListBox;
+  end;
 end;
 
 procedure TFrmNewSiteLink.Button_RemoveClick(Sender: TObject);
-var
-  idx: Integer;
 begin
-  idx := ListBox_InSiteLink.ItemIndex;
-  if idx <> -1 then
-    MoveItem(fInSite, fNotInSite, idx);
+  if ListBox_InSiteLink.ItemIndex <> -1 then
+  begin
+    fNewSiteLinkLogic.MoveItemToNotInSite(ListBox_InSiteLink.ItemIndex);
+    LoadListBox;
+  end;
 end;
 
-procedure TFrmNewSiteLink.ListBox_InSiteLinkSelectionChange(Sender: TObject;
-  User: boolean);
+procedure TFrmNewSiteLink.ListBox_InSiteLinkSelectionChange(Sender: TObject; User: boolean);
 begin
-  if Length(fInSite) + Length(fNotInSite) < 3 then
+  if fNewSiteLinkLogic.GetNbSites < 3 then
     Exit;
 
   Button_Remove.Enabled := True;
   Button_Add.Enabled := False;
 end;
 
-procedure TFrmNewSiteLink.ListBox_NotInSiteLinkSelectionChange(Sender: TObject;
-  User: boolean);
+procedure TFrmNewSiteLink.ListBox_NotInSiteLinkSelectionChange(Sender: TObject; User: boolean);
 begin
-  if Length(fInSite) + Length(fNotInSite) < 3 then
+  if fNewSiteLinkLogic.GetNbSites < 3 then
     Exit;
 
   Button_Add.Enabled := True;
   Button_Remove.Enabled := False;
-end;
-
-procedure TFrmNewSiteLink.MoveItem(var Src, Dest: TLdapResultArray; Index: Integer);
-var
-  i: Integer;
-begin
-  SetLength(Dest, Length(Dest) + 1);
-  Dest[High(Dest)] := Src[Index];
-
-  for i := Index to High(Src) - 1 do
-    Src[i] := Src[i + 1];
-
-  SetLength(Src, Length(Src) - 1);
-  LoadListBox;
-end;
-
-procedure TFrmNewSiteLink.LoadListBox();
-var
-  ResultNotInSite, ResultInSite: TLdapResult;
-begin
-  ListBox_NotInSiteLink.Clear;
-  ListBox_InSiteLink.Clear;
-  
-  for ResultNotInSite in fNotInSite do
-  begin
-    ListBox_NotInSiteLink.Items.Add(ResultNotInSite.Find('name').GetReadable());
-  end;
-  
-  for ResultInSite in fInSite do
-  begin
-    ListBox_InSiteLink.Items.Add(ResultInSite.Find('name').GetReadable());
-  end;
-end;
-
-procedure TFrmNewSiteLink.GetAllSites;
-var
-  LdapResult: TLdapResult;
-begin
-  fLdap.SearchBegin();
-  fLdap.SearchScope := lssSingleLevel;
-  repeat
-    if not fLdap.Search(FormatUtf8('CN=Sites,%', [fLdap.ConfigDN]), false, FormatUtf8('(&(objectClass=site))', []), ['name', 'distinguishedName']) then
-      Exit;
-    
-    for LdapResult in fLdap.SearchResult.Items do
-    begin
-      if not Assigned(LdapResult) then
-        continue;
-  
-      SetLength(fNotInSite, fSitesRetrieved + 1);
-      fNotInSite[fSitesRetrieved] := LdapResult;
-      fSitesRetrieved += 1;
-    end;
-  until fLdap.SearchCookie = '';
-  fLdap.SearchEnd;
 end;
 
 constructor TFrmNewSiteLink.Create(TheOwner: TComponent; ALdap: TRsatLdapClient);
@@ -215,8 +127,7 @@ var
 begin
   inherited Create(TheOwner);
 
-  fLdap := ALdap;
-  fSitesRetrieved := 0;
+  fNewSiteLinkLogic := TNewSiteLinkPresenter.Create(ALdap);
 
   OwnerNewObject.Caption := rsNewObjectSiteLink;
   OwnerNewObject.Btn_Next.Action := ActionList.ActionByName('Action_Next');
@@ -227,35 +138,39 @@ begin
   OwnerNewObject.Image_Object.ImageIndex := Ord(ileADUnknown);
   OwnerNewObject.CallBack := @Load;
   
-  GetAllSites;
+  fNewSiteLinkLogic.GetAllSites;
   
-  if fSitesRetrieved < 2 then
+  if Length(fNewSiteLinkLogic.GetSitesNotInSiteLink) < 2 then
   begin
     MessageDlg(rsTooFewSitesAvailableForSiteLink, mtError,[mbOK], 0);
-    SetLength(fInSite, 1);
-    fInSite[0] := fNotInSite[0];
-    SetLength(fNotInSite, 0);
-  end;
-
-  if fSitesRetrieved = 2 then
+    if Length(fNewSiteLinkLogic.GetSitesNotInSiteLink) > 0 then
+      fNewSiteLinkLogic.MoveItemToInSite(0);
+  end
+  else if Length(fNewSiteLinkLogic.GetSitesNotInSiteLink) = 2 then
   begin
-    SetLength(fInSite, 2);
-    fInSite[0] := fNotInSite[0];
-    fInSite[1] := fNotInSite[1];
-    SetLength(fNotInSite, 0);
+    fNewSiteLinkLogic.MoveItemToInSite(0);
+    fNewSiteLinkLogic.MoveItemToInSite(0);
   end;
   
   LoadListBox;
 end;
 
+procedure TFrmNewSiteLink.LoadListBox;
+var
+  r: TLdapResult;
+begin
+  ListBox_NotInSiteLink.Clear;
+  for r in fNewSiteLinkLogic.GetSitesNotInSiteLink do
+    ListBox_NotInSiteLink.Items.Add(fNewSiteLinkLogic.GetResultName(r));
+
+  ListBox_InSiteLink.Clear;
+  for r in fNewSiteLinkLogic.GetSitesInSiteLink do
+    ListBox_InSiteLink.Items.Add(fNewSiteLinkLogic.GetResultName(r));
+end;
+
 function TFrmNewSiteLink.GetName: RawUtf8;
 begin
   Result := Edit_Name.Text;
-end;
-
-function TFrmNewSiteLink.GetSiteAttrValue(List: TLdapResultArray; idx: Integer; attr: RawUtf8): RawUtf8;
-begin
-  Result := List[idx].Find(attr).GetReadable()
 end;
 
 end.

--- a/packages/OpenRSATGUI/ufrmnewsitelink.pas
+++ b/packages/OpenRSATGUI/ufrmnewsitelink.pas
@@ -20,7 +20,6 @@ uses
 type
 
   { TFrmNewSiteLink }
-
   TFrmNewSiteLink = class(TFrame)
     Action_Next: TAction;
     ActionList: TActionList;
@@ -41,11 +40,21 @@ type
     procedure Button_AddClick(Sender: TObject);
     procedure Button_RemoveClick(Sender: TObject);
     procedure ListBox_InSiteLinkSelectionChange(Sender: TObject; User: boolean);
-    procedure ListBox_NotInSiteLinkSelectionChange(Sender: TObject;
-      User: boolean);
+    procedure ListBox_NotInSiteLinkSelectionChange(Sender: TObject; User: boolean);
+  
+type
+  { Ldap Result }
+  TLdapResultArray = array of TLdapResult;
+    
   private
     fLdap: TRsatLdapClient;
+
+    fInSite: TLdapResultArray;
+    fNotInSite: TLdapResultArray;
+
     procedure Load;
+    procedure LoadListBox;
+    procedure MoveItem(var Src, Dest: TLdapResultArray; Index: Integer);
   public
     constructor Create(TheOwner: TComponent; ALdap: TRsatLdapClient); reintroduce;
   end;
@@ -56,6 +65,7 @@ uses
   lclintf,
   mormot.net.sock,
   mormot.core.variants,
+  mormot.core.text,
   ucommon,
   ucoredatamodule,
   uvisnewobject;
@@ -79,7 +89,11 @@ begin
   try
     Attribute := AttributeList.Add('objectClass', 'top');
     Attribute.Add('siteLink');
-
+    
+    AttributeList.Add('siteList', '');
+    
+    AttributeList.Add('cost', '100');
+    AttributeList.Add('replInterval', '180');
     if not fLdap.Add(DistinguishedName, AttributeList) then
       Exit;
   finally
@@ -89,7 +103,7 @@ end;
 
 procedure TFrmNewSiteLink.Action_NextUpdate(Sender: TObject);
 begin
-  Action_Next.Enabled := (Edit_Name.Text <> '');
+  Action_Next.Enabled := (Edit_Name.Text <> '') and (Length(fInSite) >= 2);
 end;
 
 procedure TFrmNewSiteLink.Button_AddClick(Sender: TObject);
@@ -98,12 +112,7 @@ var
 begin
   idx := ListBox_NotInSiteLink.ItemIndex;
   if idx <> -1 then
-  begin
-    ListBox_InSiteLink.Items.Add(ListBox_NotInSiteLink.Items[idx]);
-    ListBox_InSiteLink.ItemIndex := ListBox_InSiteLink.Items.Count - 1;
-    ListBox_InSiteLink.SetFocus;
-    ListBox_NotInSiteLink.Items.Delete(idx);
-  end;
+    MoveItem(fNotInSite, fInSite, idx);
 end;
 
 procedure TFrmNewSiteLink.Button_RemoveClick(Sender: TObject);
@@ -112,12 +121,7 @@ var
 begin
   idx := ListBox_InSiteLink.ItemIndex;
   if idx <> -1 then
-  begin
-    ListBox_NotInSiteLink.Items.Add(ListBox_InSiteLink.Items[idx]);
-    ListBox_NotInSiteLink.ItemIndex := ListBox_NotInSiteLink.Items.Count - 1;
-    ListBox_NotInSiteLink.SetFocus;
-    ListBox_InSiteLink.Items.Delete(idx);
-  end;
+    MoveItem(fInSite, fNotInSite, idx);
 end;
 
 procedure TFrmNewSiteLink.ListBox_InSiteLinkSelectionChange(Sender: TObject;
@@ -134,9 +138,43 @@ begin
   Button_Remove.Enabled := False;
 end;
 
+procedure TFrmNewSiteLink.MoveItem(var Src, Dest: TLdapResultArray; Index: Integer);
+var
+  i: Integer;
+begin
+  SetLength(Dest, Length(Dest) + 1);
+  Dest[High(Dest)] := Src[Index];
+
+  for i := Index to High(Src) - 1 do
+    Src[i] := Src[i + 1];
+
+  SetLength(Src, Length(Src) - 1);
+  LoadListBox;
+end;
+
+procedure TFrmNewSiteLink.LoadListBox();
+var
+  ResultNotInSite, ResultInSite: TLdapResult;
+begin
+  ListBox_NotInSiteLink.Clear;
+  ListBox_InSiteLink.Clear;
+  
+  for ResultNotInSite in fNotInSite do
+  begin
+    ListBox_NotInSiteLink.Items.Add(ResultNotInSite.Find('name').GetReadable());
+  end;
+  
+  for ResultInSite in fInSite do
+  begin
+    ListBox_InSiteLink.Items.Add(ResultInSite.Find('name').GetReadable());
+  end;
+end;
+
 constructor TFrmNewSiteLink.Create(TheOwner: TComponent; ALdap: TRsatLdapClient);
 var
   OwnerNewObject: TVisNewObject absolute TheOwner;
+  Result: TLdapResult;
+  n: Integer;
 begin
   inherited Create(TheOwner);
 
@@ -150,6 +188,33 @@ begin
   OwnerNewObject.Btn_Back.Visible := False;
   OwnerNewObject.Image_Object.ImageIndex := Ord(ileADUnknown);
   OwnerNewObject.CallBack := @Load;
+
+  fLdap.SearchScope := lssSingleLevel;
+  if not fLdap.Search(FormatUtf8('CN=Sites,CN=Configuration,%', [fLdap.DefaultDN()]), false, FormatUtf8('(&(objectClass=site))', []), ['*']) then
+    Exit;
+
+  for Result in fLdap.SearchResult.Items do
+  begin
+    if not Assigned(Result) then
+      continue;
+
+    n := Length(fNotInSite);
+    SetLength(fNotInSite, n + 1);
+    fNotInSite[n] := Result;
+  end;
+  
+  if n < 1 then
+    MessageDlg('edfer', mtError,[mbOK], 0);
+  
+  if n = 1 then
+  begin
+    SetLength(fInSite, 2);
+    fInSite[0] := fNotInSite[0];
+    fInSite[1] := fNotInSite[1];
+    SetLength(fNotInSite, 0);
+  end;
+  
+  LoadListBox;
 end;
 
 end.

--- a/packages/OpenRSATGUI/ufrmnewsitelink.pas
+++ b/packages/OpenRSATGUI/ufrmnewsitelink.pas
@@ -55,6 +55,7 @@ type
     function GetName: RawUtf8;
   public
     constructor Create(TheOwner: TComponent; ALdap: TRsatLdapClient); reintroduce;
+    destructor Destroy; override;
   end;
 
 implementation
@@ -153,6 +154,12 @@ begin
   end;
   
   LoadListBox;
+end;
+
+destructor TFrmNewSiteLink.Destroy;
+begin
+  FreeAndNil(fNewSiteLinkLogic);
+  inherited Destroy;
 end;
 
 procedure TFrmNewSiteLink.LoadListBox;


### PR DESCRIPTION
### Make new site link page works

Using an LDAP search, retrieve all available sites in order to build a new site link.
A minimum of two sites is required to create a site link. If fewer than two sites are found, an error message is displayed instead of the standard constructor page.
If exactly two sites are available, they are automatically added to the new site link. Otherwise, the user can select the desired sites from a list of all available sites.

By default, the cost value is set to 100, and the replication interval is set to 180.