### PR TITLE
[FIX] Search - keep * as wildcard in basic search filter

### DIFF
--- a/packages/OpenRSATGUI/uvissearch.pas
+++ b/packages/OpenRSATGUI/uvissearch.pas
@@ -371,7 +371,7 @@ begin
       if (Filter <> '') then
         // https://ldapwiki.com/wiki/Wiki.jsp?page=Ambiguous%20Name%20Resolution
         // Ambiguous Name Resolution (aNR) is a search algorithm in Microsoft Active Directory that permits a client to search multiple Naming Attributes on objects via a single clause in a search filter
-        Filter := FormatUtf8('(anr=%*)', [LdapEscape(Filter)])
+        Filter := FormatUtf8('(anr=%*)', [LdapEscape(Filter, true)])
       else
         Filter := 'name=*';
     end;


### PR DESCRIPTION
The basic search box builds its filter with LdapEscape, which escapes the
* to \2A by default. So typing something like *smith looks for names that
literally start with an asterisk and comes back empty.

mORMot2's LdapEscape already has a KeepWildChar flag for this; passing it
through keeps * as a wildcard while the rest of the filter metacharacters
still get escaped.
